### PR TITLE
Feat/underground chamber doors

### DIFF
--- a/doors/underground_chamber_door.vmf
+++ b/doors/underground_chamber_door.vmf
@@ -1,0 +1,319 @@
+versioninfo
+{
+	"editorversion" "400"
+	"editorbuild" "9471"
+	"mapversion" "9"
+	"formatversion" "100"
+	"prefab" "0"
+}
+visgroups
+{
+}
+viewsettings
+{
+	"bSnapToGrid" "1"
+	"bShowGrid" "1"
+	"bShowLogicalGrid" "0"
+	"nGridSpacing" "8"
+	"bShow3DGrid" "0"
+	"nInstanceVisibility" "2"
+	views
+	{
+		v0
+		{
+			"3d" "1"
+			"position" "(-69.4552 -22.4907 161.311)"
+			"angle" "[44 100.001 0]"
+		}
+		v1
+		{
+			"3d" "0"
+			"position" "(-10.9359 -15.2876 16384)"
+			"zoom" "9.5844"
+		}
+		v2
+		{
+			"3d" "0"
+			"position" "(16384 -6.51663 84.0884)"
+			"zoom" "3.2098"
+		}
+		v3
+		{
+			"3d" "0"
+			"position" "(0 0 0)"
+			"zoom" "0.25"
+		}
+	}
+}
+world
+{
+	"id" "1"
+	"mapversion" "9"
+	"classname" "worldspawn"
+	"detailmaterial" "detail/detailsprites"
+	"detailvbsp" "detail.vbsp"
+	"maxblobcount" "250"
+	"maxpropscreenwidth" "-1"
+	"skyname" "sky_black_nofog"
+}
+entity
+{
+	"id" "470"
+	"classname" "logic_relay"
+	"angles" "0 0 0"
+	"targetname" "open"
+	connections
+	{
+		"OnTrigger" "doorSetAnimationopen0-1"
+		"OnTrigger" "securityDisable0-1"
+	}
+	"origin" "-16 -15.8618 120"
+	editor
+	{
+		"color" "0 100 250"
+		"visgroupshown" "1"
+		"visgroupautoshown" "1"
+		"logicalpos" "[0 0]"
+	}
+}
+entity
+{
+	"id" "478"
+	"classname" "logic_relay"
+	"angles" "0 0 0"
+	"targetname" "close"
+	connections
+	{
+		"OnTrigger" "securityEnable0-1"
+		"OnTrigger" "doorSetAnimationclose0-1"
+	}
+	"origin" "-16 -31.8618 120"
+	editor
+	{
+		"color" "0 100 250"
+		"visgroupshown" "1"
+		"visgroupautoshown" "1"
+		"logicalpos" "[0 0]"
+	}
+}
+entity
+{
+	"id" "446"
+	"classname" "func_brush"
+	"disableflashlight" "0"
+	"disablereceiveshadows" "0"
+	"disableshadowdepth" "0"
+	"disableshadows" "0"
+	"drawinfastreflection" "0"
+	"InputFilter" "0"
+	"invert_exclusion" "0"
+	"origin" "0 0 72"
+	"renderamt" "255"
+	"rendercolor" "255 255 255"
+	"renderfx" "0"
+	"rendermode" "0"
+	"shadowdepthnocache" "0"
+	"solid" "6"
+	"solidbsp" "0"
+	"Solidity" "0"
+	"spawnflags" "2"
+	"StartDisabled" "0"
+	"targetname" "security"
+	"vrad_brush_cast_shadows" "0"
+	solid
+	{
+		"id" "444"
+		side
+		{
+			"id" "334"
+			"plane" "(-8 -56 144) (-8 56 144) (8 56 144)"
+			point_data
+			{
+				"numpts" "4"
+				"point" "0 -8 -56 144"
+				"point" "1 -8 56 144"
+				"point" "2 8 56 144"
+				"point" "3 8 -56 144"
+			}
+			"material" "TOOLS/TOOLSINVISIBLE"
+			"uaxis" "[1 0 0 0] 0.25"
+			"vaxis" "[0 -1 0 0] 0.25"
+			"rotation" "0"
+			"lightmapscale" "16"
+			"smoothing_groups" "0"
+		}
+		side
+		{
+			"id" "333"
+			"plane" "(-8 56 0) (-8 -56 0) (8 -56 0)"
+			point_data
+			{
+				"numpts" "4"
+				"point" "0 -8 56 0"
+				"point" "1 -8 -56 0"
+				"point" "2 8 -56 0"
+				"point" "3 8 56 0"
+			}
+			"material" "TOOLS/TOOLSINVISIBLE"
+			"uaxis" "[1 0 0 0] 0.25"
+			"vaxis" "[0 -1 0 0] 0.25"
+			"rotation" "0"
+			"lightmapscale" "16"
+			"smoothing_groups" "0"
+		}
+		side
+		{
+			"id" "332"
+			"plane" "(-8 -56 0) (-8 56 0) (-8 56 144)"
+			point_data
+			{
+				"numpts" "4"
+				"point" "0 -8 -56 0"
+				"point" "1 -8 56 0"
+				"point" "2 -8 56 144"
+				"point" "3 -8 -56 144"
+			}
+			"material" "TOOLS/TOOLSINVISIBLE"
+			"uaxis" "[0 1 0 0] 0.25"
+			"vaxis" "[0 0 -1 0] 0.25"
+			"rotation" "0"
+			"lightmapscale" "16"
+			"smoothing_groups" "0"
+		}
+		side
+		{
+			"id" "331"
+			"plane" "(8 56 0) (8 -56 0) (8 -56 144)"
+			point_data
+			{
+				"numpts" "4"
+				"point" "0 8 56 0"
+				"point" "1 8 -56 0"
+				"point" "2 8 -56 144"
+				"point" "3 8 56 144"
+			}
+			"material" "TOOLS/TOOLSINVISIBLE"
+			"uaxis" "[0 1 0 0] 0.25"
+			"vaxis" "[0 0 -1 0] 0.25"
+			"rotation" "0"
+			"lightmapscale" "16"
+			"smoothing_groups" "0"
+		}
+		side
+		{
+			"id" "330"
+			"plane" "(-8 56 0) (8 56 0) (8 56 144)"
+			point_data
+			{
+				"numpts" "4"
+				"point" "0 -8 56 0"
+				"point" "1 8 56 0"
+				"point" "2 8 56 144"
+				"point" "3 -8 56 144"
+			}
+			"material" "TOOLS/TOOLSINVISIBLE"
+			"uaxis" "[1 0 0 0] 0.25"
+			"vaxis" "[0 0 -1 0] 0.25"
+			"rotation" "0"
+			"lightmapscale" "16"
+			"smoothing_groups" "0"
+		}
+		side
+		{
+			"id" "329"
+			"plane" "(8 -56 0) (-8 -56 0) (-8 -56 144)"
+			point_data
+			{
+				"numpts" "4"
+				"point" "0 8 -56 0"
+				"point" "1 -8 -56 0"
+				"point" "2 -8 -56 144"
+				"point" "3 8 -56 144"
+			}
+			"material" "TOOLS/TOOLSINVISIBLE"
+			"uaxis" "[1 0 0 0] 0.25"
+			"vaxis" "[0 0 -1 0] 0.25"
+			"rotation" "0"
+			"lightmapscale" "16"
+			"smoothing_groups" "0"
+		}
+		editor
+		{
+			"color" "220 30 220"
+			"visgroupshown" "1"
+			"visgroupautoshown" "1"
+		}
+	}
+	editor
+	{
+		"color" "220 30 220"
+		"visgroupshown" "1"
+		"visgroupautoshown" "1"
+		"logicalpos" "[0 500]"
+	}
+}
+entity
+{
+	"id" "3"
+	"classname" "func_instance_io_proxy"
+	"targetname" "proxy"
+	connections
+	{
+		"OnProxyRelay" "openTrigger0-1"
+		"OnProxyRelay" "closeTrigger0-1"
+	}
+	"origin" "-16 0 121"
+	editor
+	{
+		"color" "220 30 220"
+		"visgroupshown" "1"
+		"visgroupautoshown" "1"
+		"logicalpos" "[500 15500]"
+	}
+}
+entity
+{
+	"id" "5"
+	"classname" "prop_dynamic"
+	"angles" "0 0 0"
+	"animateeveryframe" "0"
+	"disablebonefollowers" "0"
+	"explodedamage" "0"
+	"explodemagnitude" "0"
+	"exploderadius" "0"
+	"fadescale" "1"
+	"health" "0"
+	"holdanimation" "0"
+	"maxanimtime" "10"
+	"minanimtime" "5"
+	"minhealthdmg" "0"
+	"model" "models/props_underground/test_chamber_door.mdl"
+	"performancemode" "0"
+	"physdamagescale" "1.0"
+	"pressuredelay" "0"
+	"randomanimation" "0"
+	"renderamt" "255"
+	"rendercolor" "255 255 255"
+	"skin" "0"
+	"solid" "6"
+	"spawnflags" "0"
+	"startdisabled" "0"
+	"suppressanimsounds" "0"
+	"targetname" "door"
+	"origin" "0 0 0"
+	editor
+	{
+		"color" "220 30 220"
+		"visgroupshown" "1"
+		"visgroupautoshown" "1"
+		"logicalpos" "[0 0]"
+	}
+}
+cameras
+{
+	"activecamera" "-1"
+}
+cordons
+{
+	"active" "0"
+}

--- a/doors/underground_chamber_door.vmf
+++ b/doors/underground_chamber_door.vmf
@@ -2,7 +2,7 @@ versioninfo
 {
 	"editorversion" "400"
 	"editorbuild" "9471"
-	"mapversion" "9"
+	"mapversion" "10"
 	"formatversion" "100"
 	"prefab" "0"
 }
@@ -22,19 +22,19 @@ viewsettings
 		v0
 		{
 			"3d" "1"
-			"position" "(-69.4552 -22.4907 161.311)"
-			"angle" "[44 100.001 0]"
+			"position" "(-52.1418 -75.9356 153.024)"
+			"angle" "[27.6 49.201 0]"
 		}
 		v1
 		{
 			"3d" "0"
-			"position" "(-10.9359 -15.2876 16384)"
+			"position" "(-10.9359 -15.2876 0)"
 			"zoom" "9.5844"
 		}
 		v2
 		{
 			"3d" "0"
-			"position" "(16384 -6.51663 84.0884)"
+			"position" "(0 -6.51663 84.0884)"
 			"zoom" "3.2098"
 		}
 		v3
@@ -48,7 +48,7 @@ viewsettings
 world
 {
 	"id" "1"
-	"mapversion" "9"
+	"mapversion" "10"
 	"classname" "worldspawn"
 	"detailmaterial" "detail/detailsprites"
 	"detailvbsp" "detail.vbsp"
@@ -66,6 +66,8 @@ entity
 	{
 		"OnTrigger" "doorSetAnimationopen0-1"
 		"OnTrigger" "securityDisable0-1"
+		"OnTrigger" "closeEnable1-1"
+		"OnTrigger" "!selfDisable0-1"
 	}
 	"origin" "-16 -15.8618 120"
 	editor
@@ -81,11 +83,14 @@ entity
 	"id" "478"
 	"classname" "logic_relay"
 	"angles" "0 0 0"
+	"startdisabled" "1"
 	"targetname" "close"
 	connections
 	{
 		"OnTrigger" "securityEnable0-1"
 		"OnTrigger" "doorSetAnimationclose0-1"
+		"OnTrigger" "!selfDisable0-1"
+		"OnTrigger" "openEnable2-1"
 	}
 	"origin" "-16 -31.8618 120"
 	editor
@@ -283,7 +288,7 @@ entity
 	"exploderadius" "0"
 	"fadescale" "1"
 	"health" "0"
-	"holdanimation" "0"
+	"holdanimation" "1"
 	"maxanimtime" "10"
 	"minanimtime" "5"
 	"minhealthdmg" "0"

--- a/doors/underground_chamber_door_auto.vmf
+++ b/doors/underground_chamber_door_auto.vmf
@@ -2,7 +2,7 @@ versioninfo
 {
 	"editorversion" "400"
 	"editorbuild" "9471"
-	"mapversion" "14"
+	"mapversion" "17"
 	"formatversion" "100"
 	"prefab" "0"
 }
@@ -28,7 +28,7 @@ viewsettings
 		v1
 		{
 			"3d" "0"
-			"position" "(21.0517 64.9751 16384)"
+			"position" "(21.0517 64.9751 0)"
 			"zoom" "5.54653"
 		}
 		v2
@@ -48,7 +48,7 @@ viewsettings
 world
 {
 	"id" "1"
-	"mapversion" "14"
+	"mapversion" "17"
 	"classname" "worldspawn"
 	"detailmaterial" "detail/detailsprites"
 	"detailvbsp" "detail.vbsp"
@@ -64,10 +64,13 @@ entity
 	"solid" "6"
 	"spawnflags" "4097"
 	"startdisabled" "0"
+	"targetname" "openTrigger"
 	"wait" "1"
 	connections
 	{
 		"OnTrigger" "doorinstance:open;Trigger0-1"
+		"OnTrigger" "!selfDisable0-1"
+		"OnTrigger" "closeTriggerEnable1-1"
 	}
 	solid
 	{
@@ -208,11 +211,14 @@ entity
 	"origin" "-40 0 64"
 	"solid" "6"
 	"spawnflags" "4097"
-	"startdisabled" "0"
+	"startdisabled" "1"
+	"targetname" "closeTrigger"
 	"wait" "1"
 	connections
 	{
 		"OnTrigger" "doorinstance:close;Trigger0-1"
+		"OnTrigger" "openTriggerEnable2-1"
+		"OnTrigger" "!selfDisable0-1"
 	}
 	solid
 	{

--- a/doors/underground_chamber_door_auto.vmf
+++ b/doors/underground_chamber_door_auto.vmf
@@ -1,0 +1,620 @@
+versioninfo
+{
+	"editorversion" "400"
+	"editorbuild" "9471"
+	"mapversion" "14"
+	"formatversion" "100"
+	"prefab" "0"
+}
+visgroups
+{
+}
+viewsettings
+{
+	"bSnapToGrid" "1"
+	"bShowGrid" "1"
+	"bShowLogicalGrid" "0"
+	"nGridSpacing" "8"
+	"bShow3DGrid" "0"
+	"nInstanceVisibility" "2"
+	views
+	{
+		v0
+		{
+			"3d" "1"
+			"position" "(16.8776 -131.519 262.969)"
+			"angle" "[53.2 359.6 0]"
+		}
+		v1
+		{
+			"3d" "0"
+			"position" "(21.0517 64.9751 16384)"
+			"zoom" "5.54653"
+		}
+		v2
+		{
+			"3d" "0"
+			"position" "(0 15.8881 -28.1507)"
+			"zoom" "2.67483"
+		}
+		v3
+		{
+			"3d" "0"
+			"position" "(0 0 0)"
+			"zoom" "0.25"
+		}
+	}
+}
+world
+{
+	"id" "1"
+	"mapversion" "14"
+	"classname" "worldspawn"
+	"detailmaterial" "detail/detailsprites"
+	"detailvbsp" "detail.vbsp"
+	"maxblobcount" "250"
+	"maxpropscreenwidth" "-1"
+	"skyname" "sky_black_nofog"
+}
+entity
+{
+	"id" "552"
+	"classname" "trigger_multiple"
+	"origin" "72 0 64"
+	"solid" "6"
+	"spawnflags" "4097"
+	"startdisabled" "0"
+	"wait" "1"
+	connections
+	{
+		"OnTrigger" "doorinstance:open;Trigger0-1"
+	}
+	solid
+	{
+		"id" "553"
+		side
+		{
+			"id" "54"
+			"plane" "(8 -96 128) (8 96 128) (136 96 128)"
+			point_data
+			{
+				"numpts" "4"
+				"point" "0 8 -96 128"
+				"point" "1 8 96 128"
+				"point" "2 136 96 128"
+				"point" "3 136 -96 128"
+			}
+			"material" "TOOLS/TOOLSTRIGGER"
+			"uaxis" "[1 0 0 32] 0.25"
+			"vaxis" "[0 -1 0 0] 0.25"
+			"rotation" "0"
+			"lightmapscale" "16"
+			"smoothing_groups" "0"
+		}
+		side
+		{
+			"id" "53"
+			"plane" "(8 96 0) (8 -96 0) (136 -96 0)"
+			point_data
+			{
+				"numpts" "4"
+				"point" "0 8 96 0"
+				"point" "1 8 -96 0"
+				"point" "2 136 -96 0"
+				"point" "3 136 96 0"
+			}
+			"material" "TOOLS/TOOLSTRIGGER"
+			"uaxis" "[1 0 0 32] 0.25"
+			"vaxis" "[0 -1 0 0] 0.25"
+			"rotation" "0"
+			"lightmapscale" "16"
+			"smoothing_groups" "0"
+		}
+		side
+		{
+			"id" "52"
+			"plane" "(8 -96 0) (8 96 0) (8 96 128)"
+			point_data
+			{
+				"numpts" "4"
+				"point" "0 8 -96 0"
+				"point" "1 8 96 0"
+				"point" "2 8 96 128"
+				"point" "3 8 -96 128"
+			}
+			"material" "TOOLS/TOOLSTRIGGER"
+			"uaxis" "[0 1 0 0] 0.25"
+			"vaxis" "[0 0 -1 8] 0.25"
+			"rotation" "0"
+			"lightmapscale" "16"
+			"smoothing_groups" "0"
+		}
+		side
+		{
+			"id" "51"
+			"plane" "(136 96 0) (136 -96 0) (136 -96 128)"
+			point_data
+			{
+				"numpts" "4"
+				"point" "0 136 96 0"
+				"point" "1 136 -96 0"
+				"point" "2 136 -96 128"
+				"point" "3 136 96 128"
+			}
+			"material" "TOOLS/TOOLSTRIGGER"
+			"uaxis" "[0 1 0 0] 0.25"
+			"vaxis" "[0 0 -1 8] 0.25"
+			"rotation" "0"
+			"lightmapscale" "16"
+			"smoothing_groups" "0"
+		}
+		side
+		{
+			"id" "50"
+			"plane" "(8 96 0) (136 96 0) (136 96 128)"
+			point_data
+			{
+				"numpts" "4"
+				"point" "0 8 96 0"
+				"point" "1 136 96 0"
+				"point" "2 136 96 128"
+				"point" "3 8 96 128"
+			}
+			"material" "TOOLS/TOOLSTRIGGER"
+			"uaxis" "[1 0 0 32] 0.25"
+			"vaxis" "[0 0 -1 8] 0.25"
+			"rotation" "0"
+			"lightmapscale" "16"
+			"smoothing_groups" "0"
+		}
+		side
+		{
+			"id" "49"
+			"plane" "(136 -96 0) (8 -96 0) (8 -96 128)"
+			point_data
+			{
+				"numpts" "4"
+				"point" "0 136 -96 0"
+				"point" "1 8 -96 0"
+				"point" "2 8 -96 128"
+				"point" "3 136 -96 128"
+			}
+			"material" "TOOLS/TOOLSTRIGGER"
+			"uaxis" "[1 0 0 32] 0.25"
+			"vaxis" "[0 0 -1 8] 0.25"
+			"rotation" "0"
+			"lightmapscale" "16"
+			"smoothing_groups" "0"
+		}
+		editor
+		{
+			"color" "220 30 220"
+			"visgroupshown" "1"
+			"visgroupautoshown" "1"
+		}
+	}
+	editor
+	{
+		"color" "220 30 220"
+		"visgroupshown" "1"
+		"visgroupautoshown" "1"
+		"logicalpos" "[0 1500]"
+	}
+}
+entity
+{
+	"id" "541"
+	"classname" "trigger_multiple"
+	"origin" "-40 0 64"
+	"solid" "6"
+	"spawnflags" "4097"
+	"startdisabled" "0"
+	"wait" "1"
+	connections
+	{
+		"OnTrigger" "doorinstance:close;Trigger0-1"
+	}
+	solid
+	{
+		"id" "537"
+		side
+		{
+			"id" "30"
+			"plane" "(-72 -80 128) (-72 80 128) (-56 80 128)"
+			point_data
+			{
+				"numpts" "4"
+				"point" "0 -72 -80 128"
+				"point" "1 -72 80 128"
+				"point" "2 -56 80 128"
+				"point" "3 -56 -80 128"
+			}
+			"material" "TOOLS/TOOLSTRIGGER"
+			"uaxis" "[1 0 0 -32] 0.25"
+			"vaxis" "[0 -1 0 0] 0.25"
+			"rotation" "0"
+			"lightmapscale" "16"
+			"smoothing_groups" "0"
+		}
+		side
+		{
+			"id" "29"
+			"plane" "(-72 80 0) (-72 -80 0) (-56 -80 0)"
+			point_data
+			{
+				"numpts" "4"
+				"point" "0 -72 80 0"
+				"point" "1 -72 -80 0"
+				"point" "2 -56 -80 0"
+				"point" "3 -56 80 0"
+			}
+			"material" "TOOLS/TOOLSTRIGGER"
+			"uaxis" "[1 0 0 -32] 0.25"
+			"vaxis" "[0 -1 0 0] 0.25"
+			"rotation" "0"
+			"lightmapscale" "16"
+			"smoothing_groups" "0"
+		}
+		side
+		{
+			"id" "28"
+			"plane" "(-72 -80 0) (-72 80 0) (-72 80 128)"
+			point_data
+			{
+				"numpts" "4"
+				"point" "0 -72 -80 0"
+				"point" "1 -72 80 0"
+				"point" "2 -72 80 128"
+				"point" "3 -72 -80 128"
+			}
+			"material" "TOOLS/TOOLSTRIGGER"
+			"uaxis" "[0 1 0 0] 0.25"
+			"vaxis" "[0 0 -1 0] 0.25"
+			"rotation" "0"
+			"lightmapscale" "16"
+			"smoothing_groups" "0"
+		}
+		side
+		{
+			"id" "27"
+			"plane" "(-56 80 0) (-56 -80 0) (-56 -80 128)"
+			point_data
+			{
+				"numpts" "4"
+				"point" "0 -56 80 0"
+				"point" "1 -56 -80 0"
+				"point" "2 -56 -80 128"
+				"point" "3 -56 80 128"
+			}
+			"material" "TOOLS/TOOLSTRIGGER"
+			"uaxis" "[0 1 0 0] 0.25"
+			"vaxis" "[0 0 -1 0] 0.25"
+			"rotation" "0"
+			"lightmapscale" "16"
+			"smoothing_groups" "0"
+		}
+		side
+		{
+			"id" "26"
+			"plane" "(-72 80 0) (-56 80 0) (-56 80 128)"
+			point_data
+			{
+				"numpts" "4"
+				"point" "0 -72 80 0"
+				"point" "1 -56 80 0"
+				"point" "2 -56 80 128"
+				"point" "3 -72 80 128"
+			}
+			"material" "TOOLS/TOOLSTRIGGER"
+			"uaxis" "[1 0 0 -32] 0.25"
+			"vaxis" "[0 0 -1 0] 0.25"
+			"rotation" "0"
+			"lightmapscale" "16"
+			"smoothing_groups" "0"
+		}
+		side
+		{
+			"id" "25"
+			"plane" "(-56 -80 0) (-72 -80 0) (-72 -80 128)"
+			point_data
+			{
+				"numpts" "4"
+				"point" "0 -56 -80 0"
+				"point" "1 -72 -80 0"
+				"point" "2 -72 -80 128"
+				"point" "3 -56 -80 128"
+			}
+			"material" "TOOLS/TOOLSTRIGGER"
+			"uaxis" "[1 0 0 -32] 0.25"
+			"vaxis" "[0 0 -1 0] 0.25"
+			"rotation" "0"
+			"lightmapscale" "16"
+			"smoothing_groups" "0"
+		}
+		editor
+		{
+			"color" "220 30 220"
+			"visgroupshown" "1"
+			"visgroupautoshown" "1"
+		}
+	}
+	solid
+	{
+		"id" "536"
+		side
+		{
+			"id" "36"
+			"plane" "(-8 -80 128) (-8 -80 0) (-56 -80 0)"
+			point_data
+			{
+				"numpts" "4"
+				"point" "0 -8 -80 128"
+				"point" "1 -8 -80 0"
+				"point" "2 -56 -80 0"
+				"point" "3 -56 -80 128"
+			}
+			"material" "TOOLS/TOOLSTRIGGER"
+			"uaxis" "[1 0 0 -32] 0.25"
+			"vaxis" "[0 0 -1 -32] 0.25"
+			"rotation" "0"
+			"lightmapscale" "16"
+			"smoothing_groups" "0"
+		}
+		side
+		{
+			"id" "35"
+			"plane" "(-56 -64 128) (-56 -64 0) (-8 -64 0)"
+			point_data
+			{
+				"numpts" "4"
+				"point" "0 -56 -64 128"
+				"point" "1 -56 -64 0"
+				"point" "2 -8 -64 0"
+				"point" "3 -8 -64 128"
+			}
+			"material" "TOOLS/TOOLSTRIGGER"
+			"uaxis" "[1 0 0 -32] 0.25"
+			"vaxis" "[0 0 -1 -32] 0.25"
+			"rotation" "0"
+			"lightmapscale" "16"
+			"smoothing_groups" "0"
+		}
+		side
+		{
+			"id" "34"
+			"plane" "(-56 -80 128) (-56 -80 0) (-56 -64 0)"
+			point_data
+			{
+				"numpts" "4"
+				"point" "0 -56 -80 128"
+				"point" "1 -56 -80 0"
+				"point" "2 -56 -64 0"
+				"point" "3 -56 -64 128"
+			}
+			"material" "TOOLS/TOOLSTRIGGER"
+			"uaxis" "[0 0 1 32] 0.25"
+			"vaxis" "[0 1 0 32] 0.25"
+			"rotation" "0"
+			"lightmapscale" "16"
+			"smoothing_groups" "0"
+		}
+		side
+		{
+			"id" "33"
+			"plane" "(-8 -64 128) (-8 -64 0) (-8 -80 0)"
+			point_data
+			{
+				"numpts" "4"
+				"point" "0 -8 -64 128"
+				"point" "1 -8 -64 0"
+				"point" "2 -8 -80 0"
+				"point" "3 -8 -80 128"
+			}
+			"material" "TOOLS/TOOLSTRIGGER"
+			"uaxis" "[0 0 1 32] 0.25"
+			"vaxis" "[0 1 0 32] 0.25"
+			"rotation" "0"
+			"lightmapscale" "16"
+			"smoothing_groups" "0"
+		}
+		side
+		{
+			"id" "32"
+			"plane" "(-8 -80 128) (-56 -80 128) (-56 -64 128)"
+			point_data
+			{
+				"numpts" "4"
+				"point" "0 -8 -80 128"
+				"point" "1 -56 -80 128"
+				"point" "2 -56 -64 128"
+				"point" "3 -8 -64 128"
+			}
+			"material" "TOOLS/TOOLSTRIGGER"
+			"uaxis" "[1 0 0 -32] 0.25"
+			"vaxis" "[0 1 0 32] 0.25"
+			"rotation" "0"
+			"lightmapscale" "16"
+			"smoothing_groups" "0"
+		}
+		side
+		{
+			"id" "31"
+			"plane" "(-8 -64 0) (-56 -64 0) (-56 -80 0)"
+			point_data
+			{
+				"numpts" "4"
+				"point" "0 -8 -64 0"
+				"point" "1 -56 -64 0"
+				"point" "2 -56 -80 0"
+				"point" "3 -8 -80 0"
+			}
+			"material" "TOOLS/TOOLSTRIGGER"
+			"uaxis" "[1 0 0 -32] 0.25"
+			"vaxis" "[0 1 0 32] 0.25"
+			"rotation" "0"
+			"lightmapscale" "16"
+			"smoothing_groups" "0"
+		}
+		editor
+		{
+			"color" "220 30 220"
+			"visgroupshown" "1"
+			"visgroupautoshown" "1"
+		}
+	}
+	solid
+	{
+		"id" "535"
+		side
+		{
+			"id" "42"
+			"plane" "(-8 64 128) (-8 64 0) (-56 64 0)"
+			point_data
+			{
+				"numpts" "4"
+				"point" "0 -8 64 128"
+				"point" "1 -8 64 0"
+				"point" "2 -56 64 0"
+				"point" "3 -56 64 128"
+			}
+			"material" "TOOLS/TOOLSTRIGGER"
+			"uaxis" "[1 0 0 -32] 0.25"
+			"vaxis" "[0 0 -1 -32] 0.25"
+			"rotation" "0"
+			"lightmapscale" "16"
+			"smoothing_groups" "0"
+		}
+		side
+		{
+			"id" "41"
+			"plane" "(-56 80 128) (-56 80 0) (-8 80 0)"
+			point_data
+			{
+				"numpts" "4"
+				"point" "0 -56 80 128"
+				"point" "1 -56 80 0"
+				"point" "2 -8 80 0"
+				"point" "3 -8 80 128"
+			}
+			"material" "TOOLS/TOOLSTRIGGER"
+			"uaxis" "[1 0 0 -32] 0.25"
+			"vaxis" "[0 0 -1 -32] 0.25"
+			"rotation" "0"
+			"lightmapscale" "16"
+			"smoothing_groups" "0"
+		}
+		side
+		{
+			"id" "40"
+			"plane" "(-56 64 128) (-56 64 0) (-56 80 0)"
+			point_data
+			{
+				"numpts" "4"
+				"point" "0 -56 64 128"
+				"point" "1 -56 64 0"
+				"point" "2 -56 80 0"
+				"point" "3 -56 80 128"
+			}
+			"material" "TOOLS/TOOLSTRIGGER"
+			"uaxis" "[0 0 1 32] 0.25"
+			"vaxis" "[0 1 0 -32] 0.25"
+			"rotation" "0"
+			"lightmapscale" "16"
+			"smoothing_groups" "0"
+		}
+		side
+		{
+			"id" "39"
+			"plane" "(-8 80 128) (-8 80 0) (-8 64 0)"
+			point_data
+			{
+				"numpts" "4"
+				"point" "0 -8 80 128"
+				"point" "1 -8 80 0"
+				"point" "2 -8 64 0"
+				"point" "3 -8 64 128"
+			}
+			"material" "TOOLS/TOOLSTRIGGER"
+			"uaxis" "[0 0 1 32] 0.25"
+			"vaxis" "[0 1 0 -32] 0.25"
+			"rotation" "0"
+			"lightmapscale" "16"
+			"smoothing_groups" "0"
+		}
+		side
+		{
+			"id" "38"
+			"plane" "(-8 64 128) (-56 64 128) (-56 80 128)"
+			point_data
+			{
+				"numpts" "4"
+				"point" "0 -8 64 128"
+				"point" "1 -56 64 128"
+				"point" "2 -56 80 128"
+				"point" "3 -8 80 128"
+			}
+			"material" "TOOLS/TOOLSTRIGGER"
+			"uaxis" "[1 0 0 -32] 0.25"
+			"vaxis" "[0 1 0 -32] 0.25"
+			"rotation" "0"
+			"lightmapscale" "16"
+			"smoothing_groups" "0"
+		}
+		side
+		{
+			"id" "37"
+			"plane" "(-8 80 0) (-56 80 0) (-56 64 0)"
+			point_data
+			{
+				"numpts" "4"
+				"point" "0 -8 80 0"
+				"point" "1 -56 80 0"
+				"point" "2 -56 64 0"
+				"point" "3 -8 64 0"
+			}
+			"material" "TOOLS/TOOLSTRIGGER"
+			"uaxis" "[1 0 0 -32] 0.25"
+			"vaxis" "[0 1 0 -32] 0.25"
+			"rotation" "0"
+			"lightmapscale" "16"
+			"smoothing_groups" "0"
+		}
+		editor
+		{
+			"color" "220 30 220"
+			"visgroupshown" "1"
+			"visgroupautoshown" "1"
+		}
+	}
+	editor
+	{
+		"color" "220 30 220"
+		"visgroupshown" "1"
+		"visgroupautoshown" "1"
+		"logicalpos" "[0 1500]"
+	}
+}
+entity
+{
+	"id" "525"
+	"classname" "func_instance"
+	"angles" "-0 0 0"
+	"file" "instances/doors/underground_chamber_door.vmf"
+	"targetname" "door"
+	"origin" "0 0 0"
+	editor
+	{
+		"color" "220 30 220"
+		"visgroupshown" "1"
+		"visgroupautoshown" "1"
+		"logicalpos" "[0 0]"
+	}
+}
+cameras
+{
+	"activecamera" "-1"
+}
+cordons
+{
+	"active" "0"
+}

--- a/doors/underground_chamber_door_auto_closebehind.vmf
+++ b/doors/underground_chamber_door_auto_closebehind.vmf
@@ -2,7 +2,7 @@ versioninfo
 {
 	"editorversion" "400"
 	"editorbuild" "9471"
-	"mapversion" "17"
+	"mapversion" "19"
 	"formatversion" "100"
 	"prefab" "0"
 }
@@ -22,13 +22,13 @@ viewsettings
 		v0
 		{
 			"3d" "1"
-			"position" "(-16.5583 -77.1656 204.93)"
-			"angle" "[58.8 360 0]"
+			"position" "(-10.1602 -97.7682 203.473)"
+			"angle" "[44.4 337.6 0]"
 		}
 		v1
 		{
 			"3d" "0"
-			"position" "(11.7207 64.7618 16384)"
+			"position" "(11.7207 64.7618 0)"
 			"zoom" "3.85175"
 		}
 		v2
@@ -48,7 +48,7 @@ viewsettings
 world
 {
 	"id" "1"
-	"mapversion" "17"
+	"mapversion" "19"
 	"classname" "worldspawn"
 	"detailmaterial" "detail/detailsprites"
 	"detailvbsp" "detail.vbsp"
@@ -103,6 +103,7 @@ entity
 	connections
 	{
 		"OnTrigger" "doorinstance:open;Trigger0-1"
+		"OnTrigger" "closeTriggerBehindEnable1-1"
 	}
 	"origin" "-40 -56 120"
 	editor
@@ -120,11 +121,13 @@ entity
 	"origin" "-40 0 64"
 	"solid" "6"
 	"spawnflags" "4097"
-	"startdisabled" "0"
+	"startdisabled" "1"
+	"targetname" "closeTriggerBehind"
 	"wait" "1"
 	connections
 	{
 		"OnTrigger" "doorinstance:close;Trigger0-1"
+		"OnTrigger" "!selfDisable0-1"
 	}
 	solid
 	{

--- a/doors/underground_chamber_door_auto_closebehind.vmf
+++ b/doors/underground_chamber_door_auto_closebehind.vmf
@@ -1,0 +1,532 @@
+versioninfo
+{
+	"editorversion" "400"
+	"editorbuild" "9471"
+	"mapversion" "17"
+	"formatversion" "100"
+	"prefab" "0"
+}
+visgroups
+{
+}
+viewsettings
+{
+	"bSnapToGrid" "1"
+	"bShowGrid" "1"
+	"bShowLogicalGrid" "0"
+	"nGridSpacing" "8"
+	"bShow3DGrid" "0"
+	"nInstanceVisibility" "2"
+	views
+	{
+		v0
+		{
+			"3d" "1"
+			"position" "(-16.5583 -77.1656 204.93)"
+			"angle" "[58.8 360 0]"
+		}
+		v1
+		{
+			"3d" "0"
+			"position" "(11.7207 64.7618 16384)"
+			"zoom" "3.85175"
+		}
+		v2
+		{
+			"3d" "0"
+			"position" "(0 0 0)"
+			"zoom" "0.25"
+		}
+		v3
+		{
+			"3d" "0"
+			"position" "(0 0 0)"
+			"zoom" "0.25"
+		}
+	}
+}
+world
+{
+	"id" "1"
+	"mapversion" "17"
+	"classname" "worldspawn"
+	"detailmaterial" "detail/detailsprites"
+	"detailvbsp" "detail.vbsp"
+	"maxblobcount" "250"
+	"maxpropscreenwidth" "-1"
+	"skyname" "sky_black_nofog"
+}
+entity
+{
+	"id" "560"
+	"classname" "func_instance_io_proxy"
+	"targetname" "proxy"
+	connections
+	{
+		"OnProxyRelay" "openTrigger0-1"
+		"OnProxyRelay" "closeTrigger0-1"
+	}
+	"origin" "-24 -56 120"
+	editor
+	{
+		"color" "220 30 220"
+		"visgroupshown" "1"
+		"visgroupautoshown" "1"
+		"logicalpos" "[0 0]"
+	}
+}
+entity
+{
+	"id" "564"
+	"classname" "logic_relay"
+	"angles" "0 0 0"
+	"targetname" "close"
+	connections
+	{
+		"OnTrigger" "doorinstance:close;Trigger0-1"
+	}
+	"origin" "-56 -56 120"
+	editor
+	{
+		"color" "0 100 250"
+		"visgroupshown" "1"
+		"visgroupautoshown" "1"
+		"logicalpos" "[0 500]"
+	}
+}
+entity
+{
+	"id" "570"
+	"classname" "logic_relay"
+	"angles" "0 0 0"
+	"targetname" "open"
+	connections
+	{
+		"OnTrigger" "doorinstance:open;Trigger0-1"
+	}
+	"origin" "-40 -56 120"
+	editor
+	{
+		"color" "0 100 250"
+		"visgroupshown" "1"
+		"visgroupautoshown" "1"
+		"logicalpos" "[0 500]"
+	}
+}
+entity
+{
+	"id" "541"
+	"classname" "trigger_multiple"
+	"origin" "-40 0 64"
+	"solid" "6"
+	"spawnflags" "4097"
+	"startdisabled" "0"
+	"wait" "1"
+	connections
+	{
+		"OnTrigger" "doorinstance:close;Trigger0-1"
+	}
+	solid
+	{
+		"id" "537"
+		side
+		{
+			"id" "30"
+			"plane" "(-72 -80 128) (-72 80 128) (-56 80 128)"
+			point_data
+			{
+				"numpts" "4"
+				"point" "0 -72 -80 128"
+				"point" "1 -72 80 128"
+				"point" "2 -56 80 128"
+				"point" "3 -56 -80 128"
+			}
+			"material" "TOOLS/TOOLSTRIGGER"
+			"uaxis" "[1 0 0 -32] 0.25"
+			"vaxis" "[0 -1 0 0] 0.25"
+			"rotation" "0"
+			"lightmapscale" "16"
+			"smoothing_groups" "0"
+		}
+		side
+		{
+			"id" "29"
+			"plane" "(-72 80 0) (-72 -80 0) (-56 -80 0)"
+			point_data
+			{
+				"numpts" "4"
+				"point" "0 -72 80 0"
+				"point" "1 -72 -80 0"
+				"point" "2 -56 -80 0"
+				"point" "3 -56 80 0"
+			}
+			"material" "TOOLS/TOOLSTRIGGER"
+			"uaxis" "[1 0 0 -32] 0.25"
+			"vaxis" "[0 -1 0 0] 0.25"
+			"rotation" "0"
+			"lightmapscale" "16"
+			"smoothing_groups" "0"
+		}
+		side
+		{
+			"id" "28"
+			"plane" "(-72 -80 0) (-72 80 0) (-72 80 128)"
+			point_data
+			{
+				"numpts" "4"
+				"point" "0 -72 -80 0"
+				"point" "1 -72 80 0"
+				"point" "2 -72 80 128"
+				"point" "3 -72 -80 128"
+			}
+			"material" "TOOLS/TOOLSTRIGGER"
+			"uaxis" "[0 1 0 0] 0.25"
+			"vaxis" "[0 0 -1 0] 0.25"
+			"rotation" "0"
+			"lightmapscale" "16"
+			"smoothing_groups" "0"
+		}
+		side
+		{
+			"id" "27"
+			"plane" "(-56 80 0) (-56 -80 0) (-56 -80 128)"
+			point_data
+			{
+				"numpts" "4"
+				"point" "0 -56 80 0"
+				"point" "1 -56 -80 0"
+				"point" "2 -56 -80 128"
+				"point" "3 -56 80 128"
+			}
+			"material" "TOOLS/TOOLSTRIGGER"
+			"uaxis" "[0 1 0 0] 0.25"
+			"vaxis" "[0 0 -1 0] 0.25"
+			"rotation" "0"
+			"lightmapscale" "16"
+			"smoothing_groups" "0"
+		}
+		side
+		{
+			"id" "26"
+			"plane" "(-72 80 0) (-56 80 0) (-56 80 128)"
+			point_data
+			{
+				"numpts" "4"
+				"point" "0 -72 80 0"
+				"point" "1 -56 80 0"
+				"point" "2 -56 80 128"
+				"point" "3 -72 80 128"
+			}
+			"material" "TOOLS/TOOLSTRIGGER"
+			"uaxis" "[1 0 0 -32] 0.25"
+			"vaxis" "[0 0 -1 0] 0.25"
+			"rotation" "0"
+			"lightmapscale" "16"
+			"smoothing_groups" "0"
+		}
+		side
+		{
+			"id" "25"
+			"plane" "(-56 -80 0) (-72 -80 0) (-72 -80 128)"
+			point_data
+			{
+				"numpts" "4"
+				"point" "0 -56 -80 0"
+				"point" "1 -72 -80 0"
+				"point" "2 -72 -80 128"
+				"point" "3 -56 -80 128"
+			}
+			"material" "TOOLS/TOOLSTRIGGER"
+			"uaxis" "[1 0 0 -32] 0.25"
+			"vaxis" "[0 0 -1 0] 0.25"
+			"rotation" "0"
+			"lightmapscale" "16"
+			"smoothing_groups" "0"
+		}
+		editor
+		{
+			"color" "220 30 220"
+			"visgroupshown" "1"
+			"visgroupautoshown" "1"
+		}
+	}
+	solid
+	{
+		"id" "536"
+		side
+		{
+			"id" "36"
+			"plane" "(-8 -80 128) (-8 -80 0) (-56 -80 0)"
+			point_data
+			{
+				"numpts" "4"
+				"point" "0 -8 -80 128"
+				"point" "1 -8 -80 0"
+				"point" "2 -56 -80 0"
+				"point" "3 -56 -80 128"
+			}
+			"material" "TOOLS/TOOLSTRIGGER"
+			"uaxis" "[1 0 0 -32] 0.25"
+			"vaxis" "[0 0 -1 -32] 0.25"
+			"rotation" "0"
+			"lightmapscale" "16"
+			"smoothing_groups" "0"
+		}
+		side
+		{
+			"id" "35"
+			"plane" "(-56 -64 128) (-56 -64 0) (-8 -64 0)"
+			point_data
+			{
+				"numpts" "4"
+				"point" "0 -56 -64 128"
+				"point" "1 -56 -64 0"
+				"point" "2 -8 -64 0"
+				"point" "3 -8 -64 128"
+			}
+			"material" "TOOLS/TOOLSTRIGGER"
+			"uaxis" "[1 0 0 -32] 0.25"
+			"vaxis" "[0 0 -1 -32] 0.25"
+			"rotation" "0"
+			"lightmapscale" "16"
+			"smoothing_groups" "0"
+		}
+		side
+		{
+			"id" "34"
+			"plane" "(-56 -80 128) (-56 -80 0) (-56 -64 0)"
+			point_data
+			{
+				"numpts" "4"
+				"point" "0 -56 -80 128"
+				"point" "1 -56 -80 0"
+				"point" "2 -56 -64 0"
+				"point" "3 -56 -64 128"
+			}
+			"material" "TOOLS/TOOLSTRIGGER"
+			"uaxis" "[0 0 1 32] 0.25"
+			"vaxis" "[0 1 0 32] 0.25"
+			"rotation" "0"
+			"lightmapscale" "16"
+			"smoothing_groups" "0"
+		}
+		side
+		{
+			"id" "33"
+			"plane" "(-8 -64 128) (-8 -64 0) (-8 -80 0)"
+			point_data
+			{
+				"numpts" "4"
+				"point" "0 -8 -64 128"
+				"point" "1 -8 -64 0"
+				"point" "2 -8 -80 0"
+				"point" "3 -8 -80 128"
+			}
+			"material" "TOOLS/TOOLSTRIGGER"
+			"uaxis" "[0 0 1 32] 0.25"
+			"vaxis" "[0 1 0 32] 0.25"
+			"rotation" "0"
+			"lightmapscale" "16"
+			"smoothing_groups" "0"
+		}
+		side
+		{
+			"id" "32"
+			"plane" "(-8 -80 128) (-56 -80 128) (-56 -64 128)"
+			point_data
+			{
+				"numpts" "4"
+				"point" "0 -8 -80 128"
+				"point" "1 -56 -80 128"
+				"point" "2 -56 -64 128"
+				"point" "3 -8 -64 128"
+			}
+			"material" "TOOLS/TOOLSTRIGGER"
+			"uaxis" "[1 0 0 -32] 0.25"
+			"vaxis" "[0 1 0 32] 0.25"
+			"rotation" "0"
+			"lightmapscale" "16"
+			"smoothing_groups" "0"
+		}
+		side
+		{
+			"id" "31"
+			"plane" "(-8 -64 0) (-56 -64 0) (-56 -80 0)"
+			point_data
+			{
+				"numpts" "4"
+				"point" "0 -8 -64 0"
+				"point" "1 -56 -64 0"
+				"point" "2 -56 -80 0"
+				"point" "3 -8 -80 0"
+			}
+			"material" "TOOLS/TOOLSTRIGGER"
+			"uaxis" "[1 0 0 -32] 0.25"
+			"vaxis" "[0 1 0 32] 0.25"
+			"rotation" "0"
+			"lightmapscale" "16"
+			"smoothing_groups" "0"
+		}
+		editor
+		{
+			"color" "220 30 220"
+			"visgroupshown" "1"
+			"visgroupautoshown" "1"
+		}
+	}
+	solid
+	{
+		"id" "535"
+		side
+		{
+			"id" "42"
+			"plane" "(-8 64 128) (-8 64 0) (-56 64 0)"
+			point_data
+			{
+				"numpts" "4"
+				"point" "0 -8 64 128"
+				"point" "1 -8 64 0"
+				"point" "2 -56 64 0"
+				"point" "3 -56 64 128"
+			}
+			"material" "TOOLS/TOOLSTRIGGER"
+			"uaxis" "[1 0 0 -32] 0.25"
+			"vaxis" "[0 0 -1 -32] 0.25"
+			"rotation" "0"
+			"lightmapscale" "16"
+			"smoothing_groups" "0"
+		}
+		side
+		{
+			"id" "41"
+			"plane" "(-56 80 128) (-56 80 0) (-8 80 0)"
+			point_data
+			{
+				"numpts" "4"
+				"point" "0 -56 80 128"
+				"point" "1 -56 80 0"
+				"point" "2 -8 80 0"
+				"point" "3 -8 80 128"
+			}
+			"material" "TOOLS/TOOLSTRIGGER"
+			"uaxis" "[1 0 0 -32] 0.25"
+			"vaxis" "[0 0 -1 -32] 0.25"
+			"rotation" "0"
+			"lightmapscale" "16"
+			"smoothing_groups" "0"
+		}
+		side
+		{
+			"id" "40"
+			"plane" "(-56 64 128) (-56 64 0) (-56 80 0)"
+			point_data
+			{
+				"numpts" "4"
+				"point" "0 -56 64 128"
+				"point" "1 -56 64 0"
+				"point" "2 -56 80 0"
+				"point" "3 -56 80 128"
+			}
+			"material" "TOOLS/TOOLSTRIGGER"
+			"uaxis" "[0 0 1 32] 0.25"
+			"vaxis" "[0 1 0 -32] 0.25"
+			"rotation" "0"
+			"lightmapscale" "16"
+			"smoothing_groups" "0"
+		}
+		side
+		{
+			"id" "39"
+			"plane" "(-8 80 128) (-8 80 0) (-8 64 0)"
+			point_data
+			{
+				"numpts" "4"
+				"point" "0 -8 80 128"
+				"point" "1 -8 80 0"
+				"point" "2 -8 64 0"
+				"point" "3 -8 64 128"
+			}
+			"material" "TOOLS/TOOLSTRIGGER"
+			"uaxis" "[0 0 1 32] 0.25"
+			"vaxis" "[0 1 0 -32] 0.25"
+			"rotation" "0"
+			"lightmapscale" "16"
+			"smoothing_groups" "0"
+		}
+		side
+		{
+			"id" "38"
+			"plane" "(-8 64 128) (-56 64 128) (-56 80 128)"
+			point_data
+			{
+				"numpts" "4"
+				"point" "0 -8 64 128"
+				"point" "1 -56 64 128"
+				"point" "2 -56 80 128"
+				"point" "3 -8 80 128"
+			}
+			"material" "TOOLS/TOOLSTRIGGER"
+			"uaxis" "[1 0 0 -32] 0.25"
+			"vaxis" "[0 1 0 -32] 0.25"
+			"rotation" "0"
+			"lightmapscale" "16"
+			"smoothing_groups" "0"
+		}
+		side
+		{
+			"id" "37"
+			"plane" "(-8 80 0) (-56 80 0) (-56 64 0)"
+			point_data
+			{
+				"numpts" "4"
+				"point" "0 -8 80 0"
+				"point" "1 -56 80 0"
+				"point" "2 -56 64 0"
+				"point" "3 -8 64 0"
+			}
+			"material" "TOOLS/TOOLSTRIGGER"
+			"uaxis" "[1 0 0 -32] 0.25"
+			"vaxis" "[0 1 0 -32] 0.25"
+			"rotation" "0"
+			"lightmapscale" "16"
+			"smoothing_groups" "0"
+		}
+		editor
+		{
+			"color" "220 30 220"
+			"visgroupshown" "1"
+			"visgroupautoshown" "1"
+		}
+	}
+	editor
+	{
+		"color" "220 30 220"
+		"visgroupshown" "1"
+		"visgroupautoshown" "1"
+		"logicalpos" "[0 1500]"
+	}
+}
+entity
+{
+	"id" "525"
+	"classname" "func_instance"
+	"angles" "-0 0 0"
+	"file" "instances/doors/underground_chamber_door.vmf"
+	"targetname" "door"
+	"origin" "0 0 0"
+	editor
+	{
+		"color" "220 30 220"
+		"visgroupshown" "1"
+		"visgroupautoshown" "1"
+		"logicalpos" "[0 0]"
+	}
+}
+cameras
+{
+	"activecamera" "-1"
+}
+cordons
+{
+	"active" "0"
+}

--- a/doors/underground_chamber_door_auto_semi.vmf
+++ b/doors/underground_chamber_door_auto_semi.vmf
@@ -2,7 +2,7 @@ versioninfo
 {
 	"editorversion" "400"
 	"editorbuild" "9471"
-	"mapversion" "16"
+	"mapversion" "18"
 	"formatversion" "100"
 	"prefab" "0"
 }
@@ -22,13 +22,13 @@ viewsettings
 		v0
 		{
 			"3d" "1"
-			"position" "(-22.6574 147.028 279.504)"
-			"angle" "[38.4 151.6 0]"
+			"position" "(21.6052 -158.389 183.864)"
+			"angle" "[31.6 7.60006 0]"
 		}
 		v1
 		{
 			"3d" "0"
-			"position" "(77.3752 57.0212 16384)"
+			"position" "(77.3752 57.0212 0)"
 			"zoom" "3.85177"
 		}
 		v2
@@ -48,7 +48,7 @@ viewsettings
 world
 {
 	"id" "1"
-	"mapversion" "16"
+	"mapversion" "18"
 	"classname" "worldspawn"
 	"detailmaterial" "detail/detailsprites"
 	"detailvbsp" "detail.vbsp"
@@ -83,6 +83,7 @@ entity
 	connections
 	{
 		"OnTrigger" "doorinstance:close;Trigger0-1"
+		"OnTrigger" "openTriggerSemiEnable2-1"
 	}
 	"origin" "56 -72 120"
 	editor
@@ -117,10 +118,12 @@ entity
 	"solid" "6"
 	"spawnflags" "4097"
 	"startdisabled" "0"
+	"targetname" "openTriggerSemi"
 	"wait" "1"
 	connections
 	{
 		"OnTrigger" "doorinstance:open;Trigger0-1"
+		"OnTrigger" "!selfDisable0-1"
 	}
 	solid
 	{

--- a/doors/underground_chamber_door_auto_semi.vmf
+++ b/doors/underground_chamber_door_auto_semi.vmf
@@ -1,0 +1,264 @@
+versioninfo
+{
+	"editorversion" "400"
+	"editorbuild" "9471"
+	"mapversion" "16"
+	"formatversion" "100"
+	"prefab" "0"
+}
+visgroups
+{
+}
+viewsettings
+{
+	"bSnapToGrid" "1"
+	"bShowGrid" "1"
+	"bShowLogicalGrid" "0"
+	"nGridSpacing" "8"
+	"bShow3DGrid" "0"
+	"nInstanceVisibility" "2"
+	views
+	{
+		v0
+		{
+			"3d" "1"
+			"position" "(-22.6574 147.028 279.504)"
+			"angle" "[38.4 151.6 0]"
+		}
+		v1
+		{
+			"3d" "0"
+			"position" "(77.3752 57.0212 16384)"
+			"zoom" "3.85177"
+		}
+		v2
+		{
+			"3d" "0"
+			"position" "(0 0 0)"
+			"zoom" "0.25"
+		}
+		v3
+		{
+			"3d" "0"
+			"position" "(0 0 0)"
+			"zoom" "0.25"
+		}
+	}
+}
+world
+{
+	"id" "1"
+	"mapversion" "16"
+	"classname" "worldspawn"
+	"detailmaterial" "detail/detailsprites"
+	"detailvbsp" "detail.vbsp"
+	"maxblobcount" "250"
+	"maxpropscreenwidth" "-1"
+	"skyname" "sky_black_nofog"
+}
+entity
+{
+	"id" "558"
+	"classname" "func_instance_io_proxy"
+	"targetname" "proxy"
+	connections
+	{
+		"OnProxyRelay" "closeTrigger0-1"
+	}
+	"origin" "56 -88 120"
+	editor
+	{
+		"color" "220 30 220"
+		"visgroupshown" "1"
+		"visgroupautoshown" "1"
+		"logicalpos" "[0 0]"
+	}
+}
+entity
+{
+	"id" "564"
+	"classname" "logic_relay"
+	"angles" "0 0 0"
+	"targetname" "close"
+	connections
+	{
+		"OnTrigger" "doorinstance:close;Trigger0-1"
+	}
+	"origin" "56 -72 120"
+	editor
+	{
+		"color" "0 100 250"
+		"visgroupshown" "1"
+		"visgroupautoshown" "1"
+		"logicalpos" "[0 500]"
+	}
+}
+entity
+{
+	"id" "525"
+	"classname" "func_instance"
+	"angles" "-0 0 0"
+	"file" "instances/doors/underground_chamber_door.vmf"
+	"targetname" "door"
+	"origin" "0 0 0"
+	editor
+	{
+		"color" "220 30 220"
+		"visgroupshown" "1"
+		"visgroupautoshown" "1"
+		"logicalpos" "[0 0]"
+	}
+}
+entity
+{
+	"id" "543"
+	"classname" "trigger_multiple"
+	"origin" "72 0 64"
+	"solid" "6"
+	"spawnflags" "4097"
+	"startdisabled" "0"
+	"wait" "1"
+	connections
+	{
+		"OnTrigger" "doorinstance:open;Trigger0-1"
+	}
+	solid
+	{
+		"id" "534"
+		side
+		{
+			"id" "371"
+			"plane" "(8 -96 128) (8 96 128) (136 96 128)"
+			point_data
+			{
+				"numpts" "4"
+				"point" "0 8 -96 128"
+				"point" "1 8 96 128"
+				"point" "2 136 96 128"
+				"point" "3 136 -96 128"
+			}
+			"material" "TOOLS/TOOLSTRIGGER"
+			"uaxis" "[1 0 0 32] 0.25"
+			"vaxis" "[0 -1 0 0] 0.25"
+			"rotation" "0"
+			"lightmapscale" "16"
+			"smoothing_groups" "0"
+		}
+		side
+		{
+			"id" "372"
+			"plane" "(8 96 0) (8 -96 0) (136 -96 0)"
+			point_data
+			{
+				"numpts" "4"
+				"point" "0 8 96 0"
+				"point" "1 8 -96 0"
+				"point" "2 136 -96 0"
+				"point" "3 136 96 0"
+			}
+			"material" "TOOLS/TOOLSTRIGGER"
+			"uaxis" "[1 0 0 32] 0.25"
+			"vaxis" "[0 -1 0 0] 0.25"
+			"rotation" "0"
+			"lightmapscale" "16"
+			"smoothing_groups" "0"
+		}
+		side
+		{
+			"id" "373"
+			"plane" "(8 -96 0) (8 96 0) (8 96 128)"
+			point_data
+			{
+				"numpts" "4"
+				"point" "0 8 -96 0"
+				"point" "1 8 96 0"
+				"point" "2 8 96 128"
+				"point" "3 8 -96 128"
+			}
+			"material" "TOOLS/TOOLSTRIGGER"
+			"uaxis" "[0 1 0 0] 0.25"
+			"vaxis" "[0 0 -1 0] 0.25"
+			"rotation" "0"
+			"lightmapscale" "16"
+			"smoothing_groups" "0"
+		}
+		side
+		{
+			"id" "374"
+			"plane" "(136 96 0) (136 -96 0) (136 -96 128)"
+			point_data
+			{
+				"numpts" "4"
+				"point" "0 136 96 0"
+				"point" "1 136 -96 0"
+				"point" "2 136 -96 128"
+				"point" "3 136 96 128"
+			}
+			"material" "TOOLS/TOOLSTRIGGER"
+			"uaxis" "[0 1 0 0] 0.25"
+			"vaxis" "[0 0 -1 0] 0.25"
+			"rotation" "0"
+			"lightmapscale" "16"
+			"smoothing_groups" "0"
+		}
+		side
+		{
+			"id" "375"
+			"plane" "(8 96 0) (136 96 0) (136 96 128)"
+			point_data
+			{
+				"numpts" "4"
+				"point" "0 8 96 0"
+				"point" "1 136 96 0"
+				"point" "2 136 96 128"
+				"point" "3 8 96 128"
+			}
+			"material" "TOOLS/TOOLSTRIGGER"
+			"uaxis" "[1 0 0 32] 0.25"
+			"vaxis" "[0 0 -1 0] 0.25"
+			"rotation" "0"
+			"lightmapscale" "16"
+			"smoothing_groups" "0"
+		}
+		side
+		{
+			"id" "376"
+			"plane" "(136 -96 0) (8 -96 0) (8 -96 128)"
+			point_data
+			{
+				"numpts" "4"
+				"point" "0 136 -96 0"
+				"point" "1 8 -96 0"
+				"point" "2 8 -96 128"
+				"point" "3 136 -96 128"
+			}
+			"material" "TOOLS/TOOLSTRIGGER"
+			"uaxis" "[1 0 0 32] 0.25"
+			"vaxis" "[0 0 -1 0] 0.25"
+			"rotation" "0"
+			"lightmapscale" "16"
+			"smoothing_groups" "0"
+		}
+		editor
+		{
+			"color" "220 30 220"
+			"visgroupshown" "1"
+			"visgroupautoshown" "1"
+		}
+	}
+	editor
+	{
+		"color" "220 30 220"
+		"visgroupshown" "1"
+		"visgroupautoshown" "1"
+		"logicalpos" "[0 1500]"
+	}
+}
+cameras
+{
+	"activecamera" "-1"
+}
+cordons
+{
+	"active" "0"
+}


### PR DESCRIPTION
Added 4 new underground test chamber door instances. The doors follow the normal test chamber instances except the area portal door. All doors are aligned to fit inside door frames. Feel free to make changes.

- underground_chamber_door
- underground_chamber_door_auto
- underground_chamber_door_auto_closebehind
- underground_chamber_door_auto_semi

I have attached a vmf & bsp file containing all 4 doors and their uses.
[feat_underground_chamber_doors.zip](https://github.com/ChaosInitiative/P2CE-Instances/files/9689708/feat_underground_chamber_doors.zip)